### PR TITLE
modular start: fix and enhance https support in esbuild mode (rebased)

### DIFF
--- a/.changeset/plenty-jeans-call.md
+++ b/.changeset/plenty-jeans-call.md
@@ -1,0 +1,5 @@
+---
+'modular-scripts': minor
+---
+
+Fix support for SSL certificates in esbuild mode

--- a/docs/commands/start.md
+++ b/docs/commands/start.md
@@ -16,6 +16,33 @@ module within a template app, which we stage in a `node_modules/.modular`
 folder. You can develop your view as you normally would an app and it will
 automatically re-compile as you make changes in the view package.
 
+## HTTPS
+
+That are several options for enabling HTTPS in local development.
+
+Modular follows the
+[CRA implementation to enable HTTPS](https://create-react-app.dev/docs/using-https-in-development/#custom-ssl-certificate).
+
+There are two SSL certificate options available:
+
+1. Plain, self-signed (default): use the default self-signed certificate that
+   gets generated automatically (requires user to accept an invalid cert)
+2. A custom, signed certificate: you want to use a custom certificate (e.g. to
+   get a valid certificate chain that will enable authentication flows)
+
+To use custom certificates, provide the `SSL_CRT_FILE` and `SSL_KEY_FILE`
+environment variables:
+
+```bash
+HTTPS=true SSL_CRT_FILE=cert.crt SSL_KEY_FILE=cert.key yarn modular start
+```
+
+Both values can be filenames or paths to files within the project. Modular will
+look for your files:
+
+1. In the individual package directory
+2. In the monorepo root
+
 ## Options:
 
 `--verbose`: Run yarn commands with the --verbose flag set

--- a/packages/modular-scripts/package.json
+++ b/packages/modular-scripts/package.json
@@ -121,6 +121,7 @@
     "rollup-plugin-esbuild": "^5.0.0",
     "rollup-plugin-postcss": "4.0.2",
     "sass-loader": "13.0.2",
+    "selfsigned": "^2.1.1",
     "semver": "7.3.7",
     "semver-regex": "3.1.4",
     "shell-quote": "1.7.3",

--- a/packages/modular-scripts/src/__tests__/start.test.ts
+++ b/packages/modular-scripts/src/__tests__/start.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* eslint-disable testing-library/prefer-screen-queries */
+
+import path from 'path';
+import { exec } from 'child_process';
+import fs from 'fs-extra';
+import { getDocument, queries, waitFor } from 'pptr-testing-library';
+import puppeteer from 'puppeteer';
+
+import { startApp, DevServer } from './start-app';
+import { createModularTestContext, runModularForTests } from '../test/utils';
+
+// Temporary text context paths
+let tempModularRepo: string;
+
+// These tests must be executed sequentially with `--runInBand`.
+const targetedView = 'sample-app';
+
+describe('modular start', () => {
+  beforeAll(async () => {
+    tempModularRepo = createModularTestContext();
+    const tempPackagesPath = path.join(tempModularRepo, 'packages');
+    runModularForTests(
+      tempModularRepo,
+      'add sample-app --unstable-type app --unstable-name sample-app',
+    );
+
+    await fs.copyFile(
+      path.join(__dirname, 'TestApp.test-tsx'),
+      path.join(tempPackagesPath, targetedView, 'src', 'App.tsx'),
+    );
+  });
+
+  describe('when starting an app in esbuild mode', () => {
+    let browser: puppeteer.Browser;
+    let devServer: DevServer;
+    let port: string;
+
+    beforeAll(async () => {
+      const launchArgs: puppeteer.LaunchOptions &
+        puppeteer.BrowserLaunchArgumentOptions = {
+        // always run in headless - if you want to debug this locally use the env var to
+        headless: !Boolean(process.env.NO_HEADLESS_TESTS),
+        args: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+          '--allow-insecure-localhost',
+        ],
+      };
+
+      browser = await puppeteer.launch(launchArgs);
+      port = '4000';
+      devServer = await startApp(
+        targetedView,
+        {
+          env: { PORT: port, USE_MODULAR_ESBUILD: 'true', HTTPS: 'true' },
+        },
+        tempModularRepo,
+      );
+    });
+
+    afterAll(async () => {
+      if (browser) {
+        await browser.close();
+      }
+      if (devServer) {
+        // this is the problematic bit, it leaves hanging node processes
+        // despite closing the parent process. Only happens in tests!
+        void devServer.kill();
+      }
+      if (port) {
+        // kill all processes listening to the dev server port
+        exec(
+          `lsof -n -i4TCP:${port} | grep LISTEN | awk '{ print $2 }' | xargs kill -9`,
+        );
+      }
+    });
+
+    it('successfully starts up using https', async () => {
+      const page = await browser.newPage();
+      await page.goto(`https://localhost:${port}`, {});
+
+      const $document = await getDocument(page);
+
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      await waitFor(() => queries.findByTestId($document, 'test-this'));
+
+      const $text = await queries.findByText(
+        $document,
+        'this is a modular app',
+      );
+      // eslint-disable-next-line jest-dom/prefer-in-document
+      expect($text).toBeTruthy();
+    });
+  });
+});

--- a/packages/modular-scripts/src/build-scripts/common-scripts/getHttpsConfig.ts
+++ b/packages/modular-scripts/src/build-scripts/common-scripts/getHttpsConfig.ts
@@ -2,20 +2,20 @@ import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import chalk from 'chalk';
-import type { Paths } from '../../common-scripts/determineTargetPaths';
+import type { Paths } from './determineTargetPaths';
 
 // Ensure the certificate and key provided are valid and if not
 // throw an easy to debug error
 function validateKeyAndCerts({
   cert,
   key,
-  keyFile,
-  crtFile,
+  keyPath,
+  certPath,
 }: {
   cert: Buffer;
   key: Buffer;
-  keyFile: string;
-  crtFile: string;
+  keyPath: string;
+  certPath: string;
 }) {
   let encrypted;
   try {
@@ -24,7 +24,7 @@ function validateKeyAndCerts({
   } catch (err) {
     if (err instanceof Error) {
       throw new Error(
-        `The certificate "${chalk.yellow(crtFile)}" is invalid.\n${
+        `The certificate "${chalk.yellow(certPath)}" is invalid.\n${
           err.message
         }`,
       );
@@ -37,7 +37,7 @@ function validateKeyAndCerts({
     } catch (err) {
       if (err instanceof Error) {
         throw new Error(
-          `The certificate key "${chalk.yellow(keyFile)}" is invalid.\n${
+          `The certificate key "${chalk.yellow(keyPath)}" is invalid.\n${
             err.message
           }`,
         );
@@ -60,19 +60,38 @@ function readEnvFile(file: string, type: string) {
 
 // Get the https config
 // Return cert files if provided in env, otherwise just true or false
-export default function getHttpsConfig(paths: Paths) {
+export default function getHttpsConfig(paths: Paths, modularRoot: string) {
   const { SSL_CRT_FILE, SSL_KEY_FILE, HTTPS } = process.env;
   const isHttps = HTTPS === 'true';
 
+  let cert: Buffer | undefined;
+  let key: Buffer | undefined;
+  let keyPath: string | undefined;
+  let certPath: string | undefined;
+
   if (isHttps && SSL_CRT_FILE && SSL_KEY_FILE) {
-    const crtFile = path.resolve(paths.appPath, SSL_CRT_FILE);
-    const keyFile = path.resolve(paths.appPath, SSL_KEY_FILE);
+    // 1. Look in the app directory (non-root) - legacy behaviour
+    certPath = path.resolve(paths.appPath, SSL_CRT_FILE);
+    keyPath = path.resolve(paths.appPath, SSL_KEY_FILE);
+
+    try {
+      cert = readEnvFile(certPath, 'SSL_CRT_FILE');
+      key = readEnvFile(keyPath, 'SSL_KEY_FILE');
+    } catch (e) {
+      // 2. Fall back to the modular root
+      certPath = path.resolve(modularRoot, SSL_CRT_FILE);
+      keyPath = path.resolve(modularRoot, SSL_KEY_FILE);
+
+      cert = readEnvFile(certPath, 'SSL_CRT_FILE');
+      key = readEnvFile(keyPath, 'SSL_KEY_FILE');
+    }
+
     const config = {
-      cert: readEnvFile(crtFile, 'SSL_CRT_FILE'),
-      key: readEnvFile(keyFile, 'SSL_KEY_FILE'),
+      cert,
+      key,
     };
 
-    validateKeyAndCerts({ ...config, keyFile, crtFile });
+    validateKeyAndCerts({ ...config, keyPath, certPath });
     return config;
   }
   return isHttps;

--- a/packages/modular-scripts/src/build-scripts/common-scripts/getHttpsConfig.ts
+++ b/packages/modular-scripts/src/build-scripts/common-scripts/getHttpsConfig.ts
@@ -6,7 +6,7 @@ import type { Paths } from './determineTargetPaths';
 
 // Ensure the certificate and key provided are valid and if not
 // throw an easy to debug error
-function validateKeyAndCerts({
+export function validateKeyAndCerts({
   cert,
   key,
   keyPath,
@@ -47,7 +47,7 @@ function validateKeyAndCerts({
 }
 
 // Read file and throw an error if it doesn't exist
-function readEnvFile(file: string, type: string) {
+export function readEnvFile(file: string, type: string) {
   if (!fs.existsSync(file)) {
     throw new Error(
       `You specified ${chalk.cyan(

--- a/packages/modular-scripts/src/build-scripts/esbuild-scripts/utils/generateSelfSignedCert.ts
+++ b/packages/modular-scripts/src/build-scripts/esbuild-scripts/utils/generateSelfSignedCert.ts
@@ -1,0 +1,144 @@
+import fs from 'fs';
+import path from 'path';
+import selfsigned from 'selfsigned';
+import { promisify } from 'util';
+import rimraf from 'rimraf';
+
+import * as logger from '../../../utils/logger';
+
+const del = promisify(rimraf);
+
+// This code is mostly duplicated from webpack-dev-server, with some typings added.
+// To provide consistent https behaviour in esbuild mode, we use the same directories to store the generated cert.
+// See: https://github.com/webpack/webpack-dev-server/blob/master/lib/Server.js
+
+function findCacheDir() {
+  const cwd = process.cwd();
+
+  let dir: string | undefined = cwd;
+
+  for (;;) {
+    try {
+      if (fs.statSync(path.join(dir, 'package.json')).isFile()) break;
+    } catch (e) {}
+
+    const parent = path.dirname(dir);
+
+    if (dir === parent) {
+      dir = undefined;
+      break;
+    }
+
+    dir = parent;
+  }
+
+  if (!dir) {
+    return path.resolve(cwd, '.cache/webpack-dev-server');
+  } else if (process.versions.pnp === '1') {
+    return path.resolve(dir, '.pnp/.cache/webpack-dev-server');
+  } else if (process.versions.pnp === '3') {
+    return path.resolve(dir, '.yarn/.cache/webpack-dev-server');
+  }
+
+  return path.resolve(dir, 'node_modules/.cache/webpack-dev-server');
+}
+
+export async function generateSelfSignedCert() {
+  const certificateDir = findCacheDir();
+  const certificatePath = path.join(certificateDir, 'server.pem');
+  let certificateExists = fs.existsSync(certificatePath);
+
+  if (certificateExists) {
+    const certificateTtl = 1000 * 60 * 60 * 24;
+    const certificateStat = fs.statSync(certificatePath);
+
+    const now = new Date();
+
+    // cert is more than 30 days old, kill it with fire
+    if ((Number(now) - Number(certificateStat.ctime)) / certificateTtl > 30) {
+      logger.log('SSL Certificate is more than 30 days old. Removing...');
+
+      await del(certificatePath);
+
+      certificateExists = false;
+    }
+  }
+
+  if (!certificateExists) {
+    logger.log('Generating SSL Certificate...');
+
+    const attributes = [{ name: 'commonName', value: 'localhost' }];
+    const pems = selfsigned.generate(attributes, {
+      algorithm: 'sha256',
+      days: 30,
+      keySize: 2048,
+      extensions: [
+        {
+          name: 'basicConstraints',
+          cA: true,
+        },
+        {
+          name: 'keyUsage',
+          keyCertSign: true,
+          digitalSignature: true,
+          nonRepudiation: true,
+          keyEncipherment: true,
+          dataEncipherment: true,
+        },
+        {
+          name: 'extKeyUsage',
+          serverAuth: true,
+          clientAuth: true,
+          codeSigning: true,
+          timeStamping: true,
+        },
+        {
+          name: 'subjectAltName',
+          altNames: [
+            {
+              // type 2 is DNS
+              type: 2,
+              value: 'localhost',
+            },
+            {
+              type: 2,
+              value: 'localhost.localdomain',
+            },
+            {
+              type: 2,
+              value: 'lvh.me',
+            },
+            {
+              type: 2,
+              value: '*.lvh.me',
+            },
+            {
+              type: 2,
+              value: '[::1]',
+            },
+            {
+              // type 7 is IP
+              type: 7,
+              ip: '127.0.0.1',
+            },
+            {
+              type: 7,
+              ip: 'fe80::1',
+            },
+          ],
+        },
+      ],
+    });
+
+    fs.mkdirSync(certificateDir, { recursive: true });
+    fs.writeFileSync(certificatePath, pems.private + pems.cert, {
+      encoding: 'utf8',
+    });
+  }
+
+  const fakeCert = fs.readFileSync(certificatePath);
+
+  logger.log(`SSL certificate: ${certificatePath}`);
+
+  return fakeCert;
+}

--- a/packages/modular-scripts/src/build-scripts/webpack-scripts/config/webpackDevServer.config.ts
+++ b/packages/modular-scripts/src/build-scripts/webpack-scripts/config/webpackDevServer.config.ts
@@ -4,9 +4,10 @@ import evalSourceMapMiddleware from '../utils/evalSourceMapMiddleware';
 import noopServiceWorkerMiddleware from '../utils/noopServiceWorkerMiddleware';
 import ignoredFiles from '../utils/ignoredFiles';
 import redirectServedPath from '../utils/redirectServedPathMiddleware';
-import getHttpsConfig from './getHttpsConfig';
+import getHttpsConfig from '../../common-scripts/getHttpsConfig';
 import type { Configuration, ProxyConfigArray } from 'webpack-dev-server';
 import type { Paths } from '../../common-scripts/determineTargetPaths';
+import getModularRoot from '../../../utils/getModularRoot';
 
 const host = process.env.HOST || '0.0.0.0';
 const sockHost = process.env.WDS_SOCKET_HOST;
@@ -21,6 +22,7 @@ export default function createDevServerConfig(
 ): Configuration {
   const disableFirewall =
     !proxy || process.env.DANGEROUSLY_DISABLE_HOST_CHECK === 'true';
+  const modularRoot = getModularRoot();
 
   return {
     // WebpackDevServer 2.4.3 introduced a security fix that prevents remote
@@ -96,7 +98,7 @@ export default function createDevServerConfig(
       // remove last slash so user can land on `/test` instead of `/test/`
       publicPath: paths.publicUrlOrPath.slice(0, -1),
     },
-    https: getHttpsConfig(paths),
+    https: getHttpsConfig(paths, modularRoot),
     host,
     port,
     historyApiFallback: {


### PR DESCRIPTION
__Directly replaces https://github.com/jpmorganchase/modular/pull/2310, which should have been opened against this fork__

Previously, running `start` in esbuild mode with `HTTPS=true` led to an SSL protocol error. The start command for esbuild did not have the full wiring for HTTPS support.

- Fix: Fixed the dev server in esbuild mode to properly enable HTTPS, including a default generated-and-cached self-signed certificate, so that providing a custom certificate is not required by default. This is **consistent with the webpack behaviour**; the self-signed certificate generation code is the same and we store it in the same cache location.
- Enhancement: Enables the [use of custom certificates](https://create-react-app.dev/docs/using-https-in-development/#custom-ssl-certificate) in esbuild mode
- Fix: Made esbuild and webpack mode look for SSL cert files in a consistent way: the individual package directory, then the modular root. Previously, in webpack mode, it would only look for cert files in the individual package directory.
- Internal: Update the esbuild start command to exit in the same way as the webpack one